### PR TITLE
Add KivyMD GUI and Android packaging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,40 @@ probabilities.
    about and the CLI will return the scheduled date along with the home and
    away teams.
 
+## Graphical Interface
+
+Install the optional GUI dependencies and launch the modern KivyMD-powered
+interface:
+
+```bash
+pip install -e .[gui]
+stattrackerpro-gui
+```
+
+The desktop application exposes three tabs:
+
+- **Teams** – search TheSportsDB for teams by name and view records and scoring
+  trends.
+- **Events** – look up specific fixtures by their identifier to see the matchup,
+  date, venue, and status.
+- **Players** – retrieve player box score averages and any custom metrics
+  exposed by the data provider.
+
+## Building an Android APK
+
+Use [Buildozer](https://github.com/kivy/buildozer) to generate an APK from the
+same KivyMD interface:
+
+```bash
+pip install buildozer
+cd android
+buildozer -v android debug
+```
+
+The provided ``android/buildozer.spec`` file points Buildozer at the
+``gui_main.py`` helper script in the project root, which bootstraps the GUI. The
+resulting APK can be found in ``android/bin`` after a successful build.
+
 ## Testing
 
 Run the automated test suite with:

--- a/android/buildozer.spec
+++ b/android/buildozer.spec
@@ -1,0 +1,22 @@
+[app]
+title = StatTrackerPro
+description = Simple modern interface for StatTrackerPro insights
+package.name = stattrackerpro
+package.domain = org.stattrackerpro
+author = StatTrackerPro Team
+source.dir = ..
+source.include_exts = py,kv,atlas
+source.exclude_dirs = tests,.github,__pycache__
+version = 0.1.0
+requirements = python3,kivy==2.2.1,kivymd,httpx,pydantic
+orientation = portrait
+fullscreen = 0
+android.api = 33
+android.minapi = 24
+android.archs = arm64-v8a
+log_level = 2
+main = gui_main.py
+
+[buildozer]
+warn_on_root = 1
+log_level = 2

--- a/gui_main.py
+++ b/gui_main.py
@@ -1,0 +1,6 @@
+"""Helper script used by Buildozer when generating an Android APK."""
+from stattrackerpro.gui.app import main
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,14 @@ dependencies = [
 
 [project.optional-dependencies]
 server = ["uvicorn[standard]>=0.20.0"]
+gui = [
+    "kivy>=2.2.1",
+    "kivymd>=1.2.0",
+]
 
 [project.scripts]
 stattrackerpro = "stattrackerpro.cli:main"
+stattrackerpro-gui = "stattrackerpro.gui.__main__:main"
 
 [build-system]
 requires = ["setuptools>=65", "wheel"]

--- a/stattrackerpro/gui/__init__.py
+++ b/stattrackerpro/gui/__init__.py
@@ -1,0 +1,3 @@
+"""Graphical interface package for StatTrackerPro."""
+
+__all__ = []

--- a/stattrackerpro/gui/__main__.py
+++ b/stattrackerpro/gui/__main__.py
@@ -1,0 +1,9 @@
+"""Module entry point for ``python -m stattrackerpro.gui``."""
+from __future__ import annotations
+
+from .app import main
+
+__all__ = ["main"]
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/stattrackerpro/gui/app.py
+++ b/stattrackerpro/gui/app.py
@@ -1,0 +1,257 @@
+"""KivyMD powered application for the StatTrackerPro toolkit."""
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable, Iterable, Optional
+
+from kivy.clock import Clock
+from kivy.metrics import dp
+from kivy.uix.scrollview import ScrollView
+from kivymd.app import MDApp
+from kivymd.uix.boxlayout import MDBoxLayout
+from kivymd.uix.button import MDRaisedButton
+from kivymd.uix.label import MDLabel
+from kivymd.uix.list import MDList, OneLineListItem, TwoLineListItem
+from kivymd.uix.screen import MDScreen
+from kivymd.uix.tab import MDTabsBase
+from kivymd.uix.tabs import MDTabs
+from kivymd.uix.textfield import MDTextField
+from kivymd.uix.toolbar import MDTopAppBar
+
+from .controller import (
+    StatTrackerController,
+    SummaryRow,
+    format_event_summary,
+    format_player_summary,
+    format_team_summary,
+)
+
+
+class _BaseTab(MDBoxLayout, MDTabsBase):
+    """Common functionality shared by all tabs."""
+
+    def __init__(self, *, app: "StatTrackerApp", title: str, **kwargs) -> None:
+        super().__init__(orientation="vertical", padding=dp(16), spacing=dp(16), **kwargs)
+        self.app = app
+        self.text = title
+        self._status_label = MDLabel(
+            text="",
+            theme_text_color="Secondary",
+            halign="left",
+            size_hint_y=None,
+            height=dp(20),
+        )
+        self._results = MDList(size_hint_y=None)
+        self._results.bind(minimum_height=self._results.setter("height"))
+        scroll = ScrollView()
+        scroll.add_widget(self._results)
+        self.add_widget(self._status_label)
+        self.add_widget(scroll)
+
+    def set_status(self, message: str) -> None:
+        self._status_label.text = message
+
+    def clear_results(self) -> None:
+        self._results.clear_widgets()
+
+    def populate_results(self, rows: Iterable[SummaryRow]) -> None:
+        self.clear_results()
+        count = 0
+        for row in rows:
+            if row.subtitle:
+                item = TwoLineListItem(text=row.title, secondary_text=row.subtitle)
+            else:
+                item = OneLineListItem(text=row.title)
+            self._results.add_widget(item)
+            count += 1
+        if count == 0:
+            self.set_status("No results yet. Try a different search.")
+        else:
+            self.set_status(f"Showing {count} result{'s' if count != 1 else ''}.")
+
+    def on_error(self, error: Exception) -> None:
+        self.set_status(str(error))
+
+
+class _TeamSearchTab(_BaseTab):
+    def __init__(self, *, app: "StatTrackerApp") -> None:
+        super().__init__(app=app, title="Teams")
+        self._input = MDTextField(
+            hint_text="Search for a team",
+            helper_text="Enter part of the team name (e.g., Warriors)",
+            helper_text_mode="on_focus",
+            size_hint_y=None,
+            height=dp(48),
+        )
+        self._button = MDRaisedButton(text="Search", on_release=self._on_search)
+        controls = MDBoxLayout(orientation="horizontal", spacing=dp(8), size_hint_y=None, height=dp(48))
+        controls.add_widget(self._input)
+        controls.add_widget(self._button)
+        self.add_widget(controls, index=1)
+
+    def _on_search(self, *_args) -> None:
+        query = (self._input.text or "").strip()
+        if not query:
+            self.set_status("Enter a team name to start searching.")
+            return
+        self.set_status("Searching for teams…")
+        self.app.run_task(
+            task=lambda: self.app.controller.search_teams(query),
+            on_success=self._handle_results,
+            on_error=self.on_error,
+        )
+
+    def _handle_results(self, teams) -> None:
+        rows = [format_team_summary(team) for team in teams]
+        self.populate_results(rows)
+
+
+class _EventLookupTab(_BaseTab):
+    def __init__(self, *, app: "StatTrackerApp") -> None:
+        super().__init__(app=app, title="Events")
+        self._input = MDTextField(
+            hint_text="Lookup events",
+            helper_text="Comma-separated event IDs",
+            helper_text_mode="on_focus",
+            size_hint_y=None,
+            height=dp(48),
+        )
+        self._button = MDRaisedButton(text="Lookup", on_release=self._on_lookup)
+        controls = MDBoxLayout(orientation="horizontal", spacing=dp(8), size_hint_y=None, height=dp(48))
+        controls.add_widget(self._input)
+        controls.add_widget(self._button)
+        self.add_widget(controls, index=1)
+
+    def _parse_ids(self) -> Iterable[str]:
+        value = (self._input.text or "").strip()
+        for raw in value.split(","):
+            normalized = raw.strip()
+            if normalized:
+                yield normalized
+
+    def _on_lookup(self, *_args) -> None:
+        event_ids = list(self._parse_ids())
+        if not event_ids:
+            self.set_status("Add one or more event IDs to fetch details.")
+            return
+        self.set_status("Loading events…")
+        self.app.run_task(
+            task=lambda: self.app.controller.lookup_events(event_ids),
+            on_success=self._handle_results,
+            on_error=self.on_error,
+        )
+
+    def _handle_results(self, events) -> None:
+        rows = [format_event_summary(event) for event in events]
+        self.populate_results(rows)
+
+
+class _PlayerStatsTab(_BaseTab):
+    def __init__(self, *, app: "StatTrackerApp") -> None:
+        super().__init__(app=app, title="Players")
+        self._input = MDTextField(
+            hint_text="Player stats",
+            helper_text="Comma-separated player IDs",
+            helper_text_mode="on_focus",
+            size_hint_y=None,
+            height=dp(48),
+        )
+        self._button = MDRaisedButton(text="Fetch", on_release=self._on_fetch)
+        controls = MDBoxLayout(orientation="horizontal", spacing=dp(8), size_hint_y=None, height=dp(48))
+        controls.add_widget(self._input)
+        controls.add_widget(self._button)
+        self.add_widget(controls, index=1)
+
+    def _parse_ids(self) -> Iterable[str]:
+        value = (self._input.text or "").strip()
+        for raw in value.split(","):
+            normalized = raw.strip()
+            if normalized:
+                yield normalized
+
+    def _on_fetch(self, *_args) -> None:
+        player_ids = list(self._parse_ids())
+        if not player_ids:
+            self.set_status("Provide one or more player IDs to fetch stats.")
+            return
+        self.set_status("Fetching player statistics…")
+        self.app.run_task(
+            task=lambda: self.app.controller.get_player_stats(player_ids),
+            on_success=self._handle_results,
+            on_error=self.on_error,
+        )
+
+    def _handle_results(self, players) -> None:
+        rows = [format_player_summary(player) for player in players]
+        self.populate_results(rows)
+
+
+class StatTrackerApp(MDApp):
+    """KivyMD application exposing StatTrackerPro features."""
+
+    def __init__(self, controller: Optional[StatTrackerController] = None, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.controller = controller or StatTrackerController()
+        self._executor = ThreadPoolExecutor(max_workers=4)
+
+    def build(self) -> MDScreen:
+        self.title = "StatTrackerPro"
+        self.theme_cls.theme_style = "Light"
+        self.theme_cls.primary_palette = "Blue"
+        self.theme_cls.material_style = "M3"
+        screen = MDScreen()
+        root = MDBoxLayout(orientation="vertical")
+        root.add_widget(MDTopAppBar(title="StatTrackerPro", elevation=4))
+        tabs = MDTabs()
+        self._team_tab = _TeamSearchTab(app=self)
+        self._event_tab = _EventLookupTab(app=self)
+        self._player_tab = _PlayerStatsTab(app=self)
+        tabs.add_widget(self._team_tab)
+        tabs.add_widget(self._event_tab)
+        tabs.add_widget(self._player_tab)
+        root.add_widget(tabs)
+        screen.add_widget(root)
+        return screen
+
+    def run_task(
+        self,
+        *,
+        task: Callable[[], object],
+        on_success: Callable[[object], None],
+        on_error: Optional[Callable[[Exception], None]] = None,
+    ) -> None:
+        """Execute a blocking task on a worker thread and update the UI."""
+
+        def _handle_success(result: object) -> None:
+            if on_success:
+                on_success(result)
+
+        def _handle_error(exc: Exception) -> None:
+            if on_error:
+                on_error(exc)
+            else:
+                self._team_tab.set_status(str(exc))
+
+        def _worker() -> None:
+            try:
+                result = task()
+            except Exception as exc:  # pragma: no cover - UI feedback
+                Clock.schedule_once(lambda _dt: _handle_error(exc))
+            else:
+                Clock.schedule_once(lambda _dt: _handle_success(result))
+
+        self._executor.submit(_worker)
+
+    def on_stop(self) -> None:
+        super().on_stop()
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+
+def main() -> None:
+    """Entry point used by console scripts and ``python -m`` invocations."""
+
+    StatTrackerApp().run()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/stattrackerpro/gui/controller.py
+++ b/stattrackerpro/gui/controller.py
@@ -1,0 +1,134 @@
+"""Controller utilities used by the StatTrackerPro GUI."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Iterable, List, Optional
+
+from ..models import Event, PlayerStats, TeamStats
+from ..providers.base import SportsDataProvider
+from ..providers.thesportsdb import TheSportsDBProvider
+from ..services.stat_collector import StatCollector
+
+
+@dataclass
+class SummaryRow:
+    """Lightweight representation of information to display in the UI."""
+
+    title: str
+    subtitle: Optional[str] = None
+
+
+def _format_record(wins: Optional[int], losses: Optional[int]) -> Optional[str]:
+    if wins is None and losses is None:
+        return None
+    if wins is None:
+        return f"Losses: {losses}"
+    if losses is None:
+        return f"Wins: {wins}"
+    return f"Record: {wins}-{losses}"
+
+
+def _format_points(points_for: Optional[float], points_against: Optional[float]) -> Optional[str]:
+    if points_for is None and points_against is None:
+        return None
+    if points_for is None:
+        return f"Against: {points_against:.1f}"
+    if points_against is None:
+        return f"For: {points_for:.1f}"
+    return f"For/Against: {points_for:.1f}/{points_against:.1f}"
+
+
+def _format_event_header(event: Event) -> str:
+    home = event.home_team_name or event.home_team_id or "Home"
+    away = event.away_team_name or event.away_team_id or "Away"
+    return f"{away} at {home}"
+
+
+def _format_event_status(event: Event) -> Optional[str]:
+    if event.home_score is not None and event.away_score is not None:
+        return f"Score: {event.away_score}-{event.home_score}"
+    if event.status:
+        return f"Status: {event.status.title()}"
+    return None
+
+
+def format_team_summary(team: TeamStats) -> SummaryRow:
+    """Return a concise summary for display in the UI."""
+
+    title = team.name or f"Team {team.team_id}" or "Unknown Team"
+    details: List[str] = []
+    if team.league:
+        details.append(team.league)
+    if team.season:
+        details.append(f"Season {team.season}")
+    record = _format_record(team.wins, team.losses)
+    if record:
+        details.append(record)
+    points = _format_points(team.points_for, team.points_against)
+    if points:
+        details.append(points)
+    subtitle = " • ".join(details) if details else None
+    return SummaryRow(title=title, subtitle=subtitle)
+
+
+def format_event_summary(event: Event) -> SummaryRow:
+    title = _format_event_header(event)
+    details: List[str] = []
+    if isinstance(event.event_date, date):
+        details.append(event.event_date.strftime("%b %d, %Y"))
+    status = _format_event_status(event)
+    if status:
+        details.append(status)
+    if event.venue:
+        details.append(event.venue)
+    subtitle = " • ".join(details) if details else None
+    return SummaryRow(title=title, subtitle=subtitle)
+
+
+def format_player_summary(player: PlayerStats) -> SummaryRow:
+    title = player.name or f"Player {player.player_id}" or "Unknown Player"
+    details: List[str] = []
+    if player.position:
+        details.append(player.position)
+    if player.team_id:
+        details.append(f"Team {player.team_id}")
+    metrics: List[str] = []
+    if player.points_per_game is not None:
+        metrics.append(f"PTS {player.points_per_game:.1f}")
+    if player.rebounds_per_game is not None:
+        metrics.append(f"REB {player.rebounds_per_game:.1f}")
+    if player.assists_per_game is not None:
+        metrics.append(f"AST {player.assists_per_game:.1f}")
+    for key, value in player.custom_metrics.items():
+        metrics.append(f"{key.upper()} {value:.1f}")
+    if metrics:
+        details.append(", ".join(metrics))
+    subtitle = " • ".join(details) if details else None
+    return SummaryRow(title=title, subtitle=subtitle)
+
+
+class StatTrackerController:
+    """High level orchestrator used by the graphical interface."""
+
+    def __init__(self, provider: Optional[SportsDataProvider] = None) -> None:
+        self._provider = provider or TheSportsDBProvider()
+        self._collector = StatCollector(provider=self._provider)
+
+    def search_teams(self, query: str) -> List[TeamStats]:
+        return self._collector.teams(query)
+
+    def lookup_events(self, event_ids: Iterable[str]) -> List[Event]:
+        return self._collector.lookup_events(event_ids)
+
+    def get_player_stats(self, player_ids: Iterable[str]) -> List[PlayerStats]:
+        return self._collector.player_stats(player_ids)
+
+
+__all__ = [
+    "StatTrackerController",
+    "SummaryRow",
+    "format_event_summary",
+    "format_player_summary",
+    "format_team_summary",
+]

--- a/tests/test_gui_controller.py
+++ b/tests/test_gui_controller.py
@@ -1,0 +1,74 @@
+from datetime import date
+
+from stattrackerpro.gui.controller import (
+    SummaryRow,
+    format_event_summary,
+    format_player_summary,
+    format_team_summary,
+)
+from stattrackerpro.models import Event, PlayerStats, TeamStats
+
+
+def test_format_team_summary_includes_record_and_points():
+    team = TeamStats(
+        team_id="134876",
+        name="Boston Celtics",
+        league="NBA",
+        season="2024",
+        wins=10,
+        losses=2,
+        points_for=115.4,
+        points_against=104.2,
+    )
+
+    summary = format_team_summary(team)
+
+    assert isinstance(summary, SummaryRow)
+    assert summary.title == "Boston Celtics"
+    assert "Record: 10-2" in (summary.subtitle or "")
+    assert "For/Against: 115.4/104.2" in (summary.subtitle or "")
+
+
+def test_format_event_summary_with_scores():
+    event = Event(
+        event_id="2052711",
+        league_id="4328",
+        home_team_id="133604",
+        away_team_id="133602",
+        event_date=date(2024, 4, 12),
+        venue="Staples Center",
+        status="Final",
+        home_score=102,
+        away_score=98,
+        home_team_name="Los Angeles Lakers",
+        away_team_name="Golden State Warriors",
+    )
+
+    summary = format_event_summary(event)
+
+    assert summary.title == "Golden State Warriors at Los Angeles Lakers"
+    assert "Apr 12, 2024" in (summary.subtitle or "")
+    assert "Score: 98-102" in (summary.subtitle or "")
+
+
+def test_format_player_summary_with_multiple_metrics():
+    player = PlayerStats(
+        player_id="34145937",
+        name="Stephen Curry",
+        team_id="GSW",
+        position="PG",
+        points_per_game=29.8,
+        rebounds_per_game=6.1,
+        assists_per_game=6.6,
+        custom_metrics={"ts": 0.67},
+    )
+
+    summary = format_player_summary(player)
+
+    assert summary.title == "Stephen Curry"
+    subtitle = summary.subtitle or ""
+    assert "PG" in subtitle and "Team GSW" in subtitle
+    assert "PTS 29.8" in subtitle
+    assert "REB 6.1" in subtitle
+    assert "AST 6.6" in subtitle
+    assert "TS 0.7" in subtitle


### PR DESCRIPTION
## Summary
- add a KivyMD-powered desktop GUI with team, event, and player tabs backed by StatTracker services
- provide controller helpers, optional gui dependencies, and entrypoints for desktop usage
- include Buildozer configuration and helper script for generating an Android APK

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e608013ea8832c928478b9e16cf025